### PR TITLE
Rebuild for `s390x`

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,9 @@ if [[ ${target_platform} =~ .*linux-s390x.* ]]; then
   mv ${PREFIX}/bin/pandoc.static ${PREFIX}/bin/pandoc
 fi
 
-# The pandoc binary was built against libffi 3.2 but is compatible with 3.3 which uses a different SONAME
+# The pandoc binary was built against libffi 3.2 but is compatible with 3.3 and 3.4 which use
+# a different SONAME. libffi exports both .6 and .7 (which are symlinks to .8, corresponding to 3.4)
+# so just patching .6 to .7 is sufficient. 
 if [[ ${target_platform} =~ .*linux-ppc64le.* ]]; then
     patchelf --replace-needed libffi.so.6 libffi.so.7  ${PREFIX}/bin/pandoc
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ source:
     url: http://download.sinenomine.net/clefos/epel7/s390x/cmark-lib-0.23.0-4.el7.s390x.rpm         # [s390x]
 
 build:
-  number: 2
+  number: 3
   binary_relocation: False  # [osx]
   missing_dso_whitelist:  # [osx or s390x]
     - /usr/lib/libiconv.2.dylib  # [osx]


### PR DESCRIPTION
Our current build for `s390x` links against an older version of `libffi` (version `3.3`), whereas the latest versions of `python 3.9` link against `3.4`. This causes a dependency error which is apparently troubling IBM. The solution is a simple rebuild, and it can be verified through the logs that `libffi 3.4.2` is indeed linked to the executable. 

Note that the build number has been kept identical, but technically only build `0` exists for `s390x`. We could either go back to `1` or keep it as `2` to keep in sync with other platforms.